### PR TITLE
Added .gitignore and/to ignore any ghc enviorments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ghc.environment*


### PR DESCRIPTION
First: We do want a gitignore
Second: The .ghc.enviorment is the file type created when proforming the commenad `cabal install --lib --package-env . QuickCheck` as some windows comupers are forced to do to install haskell packages